### PR TITLE
unittest paths fixed in tests.xml

### DIFF
--- a/tests/gen-tests-xml.sh
+++ b/tests/gen-tests-xml.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TESTDIR=`dirname $0`
+INSTALL_PATH=$1
 DOMAIN="Application Framework"
 FEATURE="MeeGo Touch UI Framework"
 TYPE="Functional"
@@ -22,7 +23,7 @@ for TEST in `ls -d ?t_*`; do
 		fi
 
 TESTCASE_TEMPLATE="<case name=\"$TEST\" description=\"$TEST\" requirement=\"\" timeout=\"300\" insignificant=\"$INSIGNIFICANT\">
-        <step expected_result=\"0\">/usr/lib/libmlocale-tests/$TEST</step>
+        <step expected_result=\"0\">$INSTALL_PATH/$TEST</step>
       </case>
       "
 

--- a/tests/shell.pri
+++ b/tests/shell.pri
@@ -1,4 +1,7 @@
-shell_scripts.commands += $$PWD/gen-tests-xml.sh > $$OUT_PWD/tests.xml
+equals(QT_MAJOR_VERSION, 4): ml_unittest_install_path = $$[QT_INSTALL_LIBS]/libmlocale-tests
+equals(QT_MAJOR_VERSION, 5): ml_unittest_install_path = $$[QT_INSTALL_LIBS]/libmlocale-tests5
+
+shell_scripts.commands += $$PWD/gen-tests-xml.sh $${ml_unittest_install_path} > $$OUT_PWD/tests.xml
 shell_scripts.files += $$OUT_PWD/tests.xml
 shell_scripts.CONFIG += no_check_exist
 


### PR DESCRIPTION
depending on Qt version the path is different, so the tests.xml file can
be used in packages build for Qt4 and Qt5.

[qa] unittest paths fixed in tests.xml depending on Qt version
