### PR TITLE
[mlocale] Prevent assertion under MLocale::indexBucket with malformed input

### DIFF
--- a/src/micuconversions.cpp
+++ b/src/micuconversions.cpp
@@ -30,7 +30,8 @@ namespace ML10N {
 
 icu::UnicodeString MIcuConversions::qStringToUnicodeString(const QString &sourceStr)
 {
-    return UnicodeString(static_cast<const UChar *>(sourceStr.utf16()));
+    return UnicodeString(static_cast<const UChar *>(sourceStr.utf16()),
+                   sourceStr.length());
 }
 
 QString MIcuConversions::unicodeStringToQString(const icu::UnicodeString &sourceStr)

--- a/src/mlocale.cpp
+++ b/src/mlocale.cpp
@@ -3986,12 +3986,16 @@ QString MLocale::indexBucket(const QString &str, const QStringList &buckets, con
         MIcuConversions::unicodeStringToQString(
             MIcuConversions::qStringToUnicodeString(str).toUpper(
                 d->getCategoryLocale(MLocale::MLcCollate)));
+    if (strUpperCase.isEmpty())
+        return strUpperCase;
     QString firstCharacter;
-    if (strUpperCase.at(0).isHighSurrogate())
+    if (strUpperCase.at(0).isHighSurrogate() && strUpperCase.length() > 1)
         firstCharacter = strUpperCase.at(0) + strUpperCase.at(1);
     else
         firstCharacter = strUpperCase.at(0);
     firstCharacter = MLocalePrivate::removeAccents(firstCharacter);
+    if (firstCharacter.isEmpty())
+        return firstCharacter;
     // removing the accents as above also does expansions
     // like “㈠ → (一)”. If this happened, take the first character
     //  of the expansion:


### PR DESCRIPTION
We're not sure what data actually made this warn under valgrind and assert - it seems to have disappeared. Regardless, these changes are useful safety against malformed inputs.
